### PR TITLE
:lipstick: Upgrade activerecord to version 4.1.4

### DIFF
--- a/facemock.gemspec
+++ b/facemock.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", "~> 3.2.18"
+  spec.add_dependency "activerecord", "~> 4.1.4"
   spec.add_dependency "sqlite3"
   spec.add_dependency "fb_graph"
 

--- a/lib/facemock.rb
+++ b/lib/facemock.rb
@@ -5,8 +5,8 @@ require "facemock/config"
 module Facemock 
   extend self
 
-  def on
-    Facemock::FbGraph.on
+  def on(options={})
+    Facemock::FbGraph.on(options)
   end
 
   def off

--- a/lib/facemock/config/database.rb
+++ b/lib/facemock/config/database.rb
@@ -72,14 +72,12 @@ module Facemock
 
       def create_applications_table
         ActiveRecord::Migration.create_table :applications do |t|
-          t.integer :id,     :null => false
           t.string  :secret, :null => false
         end
       end
 
       def create_users_table
         ActiveRecord::Migration.create_table :users do |t|
-          t.integer   :id,             :null => false
           t.string    :name,           :null => false
           t.string    :email,          :null => false
           t.string    :password,       :null => false

--- a/lib/facemock/fb_graph.rb
+++ b/lib/facemock/fb_graph.rb
@@ -1,18 +1,26 @@
 require 'fb_graph'
+require 'facemock/config'
 require 'facemock/fb_graph/user'
 require 'facemock/fb_graph/errors'
-require "facemock/fb_graph/application"
+require 'facemock/fb_graph/application'
 
 module Facemock
   module FbGraph
     extend self
 
-    def on
+    def on(options={})
       if ::FbGraph != Facemock::FbGraph
         Object.const_set(:SourceFbGraph, ::FbGraph)
         Object.send(:remove_const, :FbGraph) if Object.constants.include?(:FbGraph)
         Object.const_set(:FbGraph, Facemock::FbGraph)
       end
+
+      if options[:database_name]
+        Facemock::Config.database(options[:database_name])
+      else
+        Facemock::Config.database
+      end
+      true
     end
 
     def off
@@ -21,6 +29,8 @@ module Facemock
         Object.const_set(:FbGraph, ::SourceFbGraph)
         Object.send(:remove_const, :SourceFbGraph) if Object.constants.include?(:FbGraph)
       end
+      Facemock::Config.reset_database
+      true
     end
   end
 end

--- a/lib/facemock/fb_graph/application.rb
+++ b/lib/facemock/fb_graph/application.rb
@@ -18,11 +18,6 @@ module Facemock
           secret = options[:secret] || rand(36**32).to_s(36)
         end
         
-        if options[:database_name]
-          Facemock::Config.database(options[:database_name])
-        else
-          Facemock::Config.database
-        end
         super(secret: secret)
         self.identifier = identifier
         save! unless Application.find_by_id_and_secret(identifier, secret)

--- a/lib/facemock/fb_graph/application/user.rb
+++ b/lib/facemock/fb_graph/application/user.rb
@@ -1,6 +1,5 @@
 require 'active_record'
 require 'facemock/fb_graph/application/user/right'
-require 'pry'
 
 module Facemock
   module FbGraph

--- a/spec/facemock/config_spec.rb
+++ b/spec/facemock/config_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'pry'
 
 describe Facemock::Config do
   let(:db_name) { ".test" }

--- a/spec/facemock/fb_graph/application_spec.rb
+++ b/spec/facemock/fb_graph/application_spec.rb
@@ -27,7 +27,10 @@ describe Facemock::FbGraph::Application do
     it { is_expected.to eq table_name }
   end
 
-  before { stub_const("Facemock::Config::Database::DEFAULT_DB_NAME", db_name) }
+  before do
+    stub_const("Facemock::Config::Database::DEFAULT_DB_NAME", db_name)
+    Facemock::Config.database
+  end
   after  { Facemock::Config.database.drop }
 
   describe '#new' do
@@ -50,9 +53,10 @@ describe Facemock::FbGraph::Application do
       end
     end
 
-    context 'with facebook app id and secret, database name option' do
+    context 'with facebook app id and secret' do
       before do
-        options = { secret: facebook_app_secret, database_name: db_name }
+        options = { secret: facebook_app_secret }
+        Facemock::FbGraph.on
         @app = Facemock::FbGraph::Application.new(facebook_app_id, options)
       end
 

--- a/spec/facemock/fb_graph/errors_spec.rb
+++ b/spec/facemock/fb_graph/errors_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe Facemock::FbGraph::Errors do
+  before do
+    Facemock::FbGraph.off
+  end
+
   it 'should have a error module' do
     expect(Facemock::FbGraph::Errors::Error).to be_truthy
     expect(Facemock::FbGraph::Errors::Error.ancestors).to include StandardError

--- a/spec/facemock/fb_graph/user_spec.rb
+++ b/spec/facemock/fb_graph/user_spec.rb
@@ -9,7 +9,10 @@ describe Facemock::FbGraph::User do
   let(:db_directory)  { File.expand_path("../../../../db", __FILE__) }
   let(:db_filepath)   { File.join(db_directory, "#{db_name}.#{adapter}") }
 
-  before { stub_const("Facemock::Config::Database::DEFAULT_DB_NAME", db_name) }
+  before do
+    stub_const("Facemock::Config::Database::DEFAULT_DB_NAME", db_name)
+    Facemock::Config.database
+  end
   after  { Facemock::Config.database.drop }
 
   describe '.me' do

--- a/spec/facemock/fb_graph_spec.rb
+++ b/spec/facemock/fb_graph_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Facemock::FbGraph do
+  let(:db_name) { ".test" }
+
   it 'should have a application class' do
     expect(Facemock::FbGraph::Application).to be_truthy
   end
@@ -12,6 +14,11 @@ describe Facemock::FbGraph do
   it 'should have a user module' do
     expect(Facemock::FbGraph::User).to be_truthy
   end
+
+  before do
+    stub_const("Facemock::Config::Database::DEFAULT_DB_NAME", db_name)
+  end
+  after  { Facemock::Config.database.drop }
 
   describe '#on' do
     subject { Facemock::FbGraph.on }

--- a/spec/facemock_spec.rb
+++ b/spec/facemock_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Facemock do
   let(:version) { "0.0.1" }
+  let(:db_name) { ".test" }
 
   describe 'VERSION' do
     subject { Facemock::VERSION }
@@ -16,14 +17,31 @@ describe Facemock do
     expect(Facemock::FbGraph).to be_truthy
   end
 
+  before do
+    stub_const("Facemock::Config::Database::DEFAULT_DB_NAME", db_name)
+  end
+  after  { Facemock::Config.database.drop }
+
   describe '#on' do
     subject { Facemock.on }
     it { is_expected.to be_truthy }
 
     context 'FbGraph' do
-      before { Facemock.on }
-      it { expect(::FbGraph).to eq Facemock::FbGraph }
-      it { expect( lambda { Facemock.on } ).not_to raise_error }
+      context 'without option' do
+        before { Facemock.on }
+        it { expect(::FbGraph).to eq Facemock::FbGraph }
+        it { expect( lambda { Facemock.on } ).not_to raise_error }
+      end
+
+      context 'with database_name option' do
+        before do
+          @options = { database_name: db_name}
+          Facemock.on(@options)
+        end
+        it { expect(::FbGraph).to eq Facemock::FbGraph }
+        it { expect( lambda { Facemock.on } ).not_to raise_error }
+        it { expect( lambda { Facemock.on(@options) } ).not_to raise_error }
+      end
     end
   end
 


### PR DESCRIPTION
ActiveRecordのバージョンを3.2.18から4.1.4に上げた。
これに伴って、以下を変更した。
- MigrateのタイミングをApplicationモデル新規作成時からMockをonにしたときに変更
- Migrationでテーブル作成時にidを指定しない
