### PR TITLE
:bulb: FM-4 : Availed identifier option when facemock user new

### DIFF
--- a/lib/facemock/user.rb
+++ b/lib/facemock/user.rb
@@ -10,12 +10,13 @@ module Facemock
 
     def initialize(options={})
       opts = Hashie::Mash.new(options)
-      @id             = (opts.id.to_i > 0) ? opts.id.to_i : ("10000" + (0..9).to_a.shuffle[0..10].join).to_i
+      id = opts.id || opts.identifier
+      @id             = (id.to_i > 0) ? id.to_i : ("10000" + (0..9).to_a.shuffle[0..10].join).to_i
       @name           = opts.name         || rand(36**10).to_s(36)
       @email          = opts.email        || name.gsub(" ", "_") + "@example.com"
       @password       = opts.password     || rand(36**10).to_s(36)
       @installed      = opts.installed    || false
-      @access_token   = opts.access_token || Digest::SHA512.hexdigest(identifier.to_s)
+      @access_token   = opts.access_token || rand(36**255).to_s(36)
       app_id = opts.application_id.to_i
       @application_id = (app_id > 0) ? app_id : nil
       @created_at     = opts.created_at

--- a/spec/facemock/user_spec.rb
+++ b/spec/facemock/user_spec.rb
@@ -99,7 +99,7 @@ describe Facemock::User do
 
         describe '.size' do
           subject { Facemock::User.new.access_token.size }
-          it { is_expected.to eq 128 }
+          it { is_expected.to be <= 255 }
         end
       end
 
@@ -123,6 +123,23 @@ describe Facemock::User do
         subject { Facemock::User.new(@opts).id }
         it { is_expected.to be > 0 }
         it { is_expected.to be < 100010000000000 }
+      end
+    end
+
+    # TODO : DOING
+    context 'with identifier option' do
+      before { @opts = { identifier: 100010000000000 } }
+      subject { Facemock::User.new(@opts) }
+      it { is_expected.to be_kind_of Facemock::User }
+
+      describe '.id' do
+        subject { Facemock::User.new(@opts).id }
+        it { is_expected.to eq @opts[:identifier] }
+      end
+
+      describe '.identifier' do
+        subject { Facemock::User.new(@opts).identifier }
+        it { is_expected.to eq @opts[:identifier] }
       end
     end
 


### PR DESCRIPTION
変更点
1. Facemock::User.newでidentificationでもid指定をできるようにした
2. Facemock::User#access_tokenのデフォルト値の長さを255文字以下に変更
