### PR TITLE
不要なコードを削除しました

### DIFF
--- a/lib/facemock/config.rb
+++ b/lib/facemock/config.rb
@@ -18,7 +18,6 @@ module Facemock
 
     def reset_database
       db = Facemock::Database.new
-      db.disconnect!
       db.drop
     end
 


### PR DESCRIPTION
Facemock::Database.dropの先頭でFacemock::Database.disconnect!が実行されるため、該当のコードは必要ないように思います
